### PR TITLE
Spike on adding basic persisted storage for journal entries

### DIFF
--- a/lib/core/helpers/format_helper.dart
+++ b/lib/core/helpers/format_helper.dart
@@ -1,0 +1,5 @@
+class FormatHelper {
+  static String formatDate(DateTime date) {
+    return "${date.year}-${date.month}-${date.day}";
+  }
+}

--- a/lib/core/helpers/permission_helper.dart
+++ b/lib/core/helpers/permission_helper.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:permission_handler/permission_handler.dart';
+
+class PermissionHelper {
+  static bool get hasValidStoragePermissions => _hasStoragePermission;
+
+  // https://pub.dev/packages/permission_handler currently only android/ios/windows support this.
+  static final bool _canSkipStoragePermissionCheck = !Platform.isAndroid && !Platform.isIOS && !Platform.isWindows;
+  static bool _hasStoragePermission = false;
+
+  static ensureStoragePermissions() async {
+    if (_canSkipStoragePermissionCheck || _hasStoragePermission) {
+      _hasStoragePermission = true;
+      return;
+    }
+
+    if (!_hasStoragePermission) {
+      _hasStoragePermission = await _requestPermission(Permission.storage, forceOpenSettings: true) ||
+          await _requestPermission(Permission.manageExternalStorage, forceOpenSettings: true);
+    }
+  }
+
+  static Future<bool> _requestPermission(Permission name, {bool forceOpenSettings = false}) async {
+    try {
+      var permission = await name.request();
+
+      if (forceOpenSettings) {
+        await _openSettingsIfNeeded(permission);
+      }
+
+      return _isAllowedPermission(permission);
+    } catch (error) {
+      return false;
+    }
+  }
+
+  static Future _openSettingsIfNeeded(PermissionStatus permissionStatus) async {
+    if (permissionStatus == PermissionStatus.permanentlyDenied) {
+      await openAppSettings();
+    }
+  }
+
+  static bool _isAllowedPermission(PermissionStatus status) {
+    return status == PermissionStatus.granted || status == PermissionStatus.limited;
+  }
+}

--- a/lib/core/helpers/storage_helper.dart
+++ b/lib/core/helpers/storage_helper.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:coconut_chronicles/core/helpers/permission_helper.dart';
+import 'package:coconut_chronicles/core/helpers/platform_helper.dart';
+import 'package:path_provider/path_provider.dart';
+
+class StorageHelper {
+  static Directory? _storageDirectory;
+
+  static Future<Directory> getStorageDirectory() async {
+    if (_storageDirectory != null) {
+      return _storageDirectory!;
+    }
+
+    if (PlatformHelper.isWeb) {
+      throw UnsupportedError("No support yet for web storage");
+    }
+
+    await PermissionHelper.ensureStoragePermissions();
+
+    _storageDirectory = await getApplicationDocumentsDirectory();
+    await _ensureDirectoryExists(_storageDirectory!);
+
+    return _storageDirectory!;
+  }
+
+  static Future _ensureDirectoryExists(Directory directory) async {
+    if (!await directory.exists()) {
+      await directory.create(recursive: true);
+    }
+  }
+}

--- a/lib/core/models/entry.dart
+++ b/lib/core/models/entry.dart
@@ -1,9 +1,19 @@
+import 'dart:convert';
+
+import 'package:coconut_chronicles/core/helpers/format_helper.dart';
+
 class EntryModel {
+  String get safeTitle => title ?? "Untitled";
+  String get safeDescription => description ?? "No description";
+  String get safeDate => date != null ? FormatHelper.formatDate(date!) : "No date";
+
   String? title;
   String? description;
   DateTime? date;
   String? country;
   List<String>? categories;
+
+  String get fileSaveName => (date ?? DateTime.now()).toIso8601String();
 
   EntryModel({
     this.title,
@@ -33,5 +43,26 @@ class EntryModel {
     date = null;
     country = null;
     categories = null;
+  }
+
+  toJson() {
+    return jsonEncode({
+      'title': title,
+      'description': description,
+      'date': date?.toIso8601String(),
+      'country': country,
+      'categories': categories,
+    });
+  }
+
+  static EntryModel fromJson(String json) {
+    var decodedJson = jsonDecode(json);
+    return EntryModel(
+      title: decodedJson['title'],
+      description: decodedJson['description'],
+      date: DateTime.parse(decodedJson['date']),
+      country: decodedJson['country'],
+      categories: decodedJson['categories'],
+    );
   }
 }

--- a/lib/core/storage/entry_storage.dart
+++ b/lib/core/storage/entry_storage.dart
@@ -1,1 +1,31 @@
-class EntryStorage {}
+import 'dart:io';
+
+import 'package:coconut_chronicles/core/helpers/storage_helper.dart';
+import 'package:coconut_chronicles/core/models/entry.dart';
+
+class EntryStorage {
+  static Map<String, EntryModel> _entries = {};
+
+  static Future saveEntry(EntryModel entry) async {
+    var storageDirectory = await StorageHelper.getStorageDirectory();
+    var file = File('${storageDirectory.path}/${entry.fileSaveName}.json');
+
+    await file.writeAsString(entry.toJson());
+  }
+
+  static Future<List<EntryModel>> loadEntries() async {
+    if (_entries.isNotEmpty) {
+      return _entries.values.toList();
+    }
+
+    var storageDirectory = await StorageHelper.getStorageDirectory();
+    var files = await storageDirectory.list().toList();
+
+    for (var file in files) {
+      var entry = EntryModel.fromJson(await File(file.path).readAsString());
+      _entries[entry.fileSaveName] = entry;
+    }
+
+    return _entries.values.toList();
+  }
+}

--- a/lib/widgets/chronicle_entry_form.dart
+++ b/lib/widgets/chronicle_entry_form.dart
@@ -1,5 +1,6 @@
 import 'package:coconut_chronicles/constants/default_constants.dart';
 import 'package:coconut_chronicles/core/models/entry.dart';
+import 'package:coconut_chronicles/core/storage/entry_storage.dart';
 import 'package:coconut_chronicles/widgets/entry_form_inputs/chip_categories.dart';
 import 'package:coconut_chronicles/widgets/entry_form_inputs/country_selector.dart';
 import 'package:coconut_chronicles/widgets/entry_form_inputs/date_selector.dart';
@@ -20,6 +21,15 @@ class _ChronicleEntryFormState extends State<ChronicleEntryForm> {
   static final DateTime _defaultDate = DateTime.now();
   final _formKey = GlobalKey<FormState>();
   final EntryModel _entry = EntryModel();
+
+  _saveEntry() async {
+    var snackContext = ScaffoldMessenger.of(context);
+    await EntryStorage.saveEntry(_entry);
+    _clearData();
+    snackContext.showSnackBar(
+      const SnackBar(content: Text('Saved chronicle entry')),
+    );
+  }
 
   _clearData() {
     setState(() {
@@ -68,10 +78,7 @@ class _ChronicleEntryFormState extends State<ChronicleEntryForm> {
             TextButton(
               onPressed: () {
                 if (_formKey.currentState!.validate()) {
-                  _clearData();
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Saved chronicle entry')),
-                  );
+                  _saveEntry();
                 }
               },
               child: const Text('Save'),

--- a/lib/widgets/chronicle_entry_list.dart
+++ b/lib/widgets/chronicle_entry_list.dart
@@ -1,0 +1,41 @@
+import 'package:coconut_chronicles/core/models/entry.dart';
+import 'package:coconut_chronicles/core/storage/entry_storage.dart';
+import 'package:flutter/material.dart';
+
+class ChronicleEntryList extends StatefulWidget {
+  const ChronicleEntryList({Key? key}) : super(key: key);
+
+  @override
+  State<ChronicleEntryList> createState() => _ChronicleEntryListState();
+}
+
+class _ChronicleEntryListState extends State<ChronicleEntryList> {
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: [
+      const Text("Past entries"),
+      SizedBox(
+          height: 300,
+          child: FutureBuilder(
+            future: EntryStorage.loadEntries(),
+            builder: (context, snapshot) {
+              if (snapshot.hasData) {
+                var entries = snapshot.data as List<EntryModel>;
+                return ListView.builder(
+                  itemCount: entries.length,
+                  itemBuilder: (context, index) {
+                    var entry = entries[index];
+                    return ListTile(
+                      title: Text(entry.safeTitle),
+                      subtitle: Text(entry.safeDate),
+                    );
+                  },
+                );
+              }
+
+              return const Center(child: CircularProgressIndicator());
+            },
+          ))
+    ]);
+  }
+}

--- a/lib/widgets/entry_form_inputs/date_selector.dart
+++ b/lib/widgets/entry_form_inputs/date_selector.dart
@@ -1,3 +1,4 @@
+import 'package:coconut_chronicles/core/helpers/format_helper.dart';
 import 'package:flutter/material.dart';
 
 class DateSelector extends StatefulWidget {
@@ -31,14 +32,10 @@ class _DateSelectorState extends State<DateSelector> {
         const Text("Date: "),
         TextButton(
           onPressed: () => _openDatePicker(),
-          child: Text(_formatDate()),
+          child: Text(FormatHelper.formatDate(_selectedDate)),
         ),
       ],
     );
-  }
-
-  String _formatDate() {
-    return "${_selectedDate.year}-${_selectedDate.month}-${_selectedDate.day}";
   }
 
   Future<void> _openDatePicker() async {

--- a/lib/widgets/home_page_drawer.dart
+++ b/lib/widgets/home_page_drawer.dart
@@ -1,4 +1,5 @@
 import 'package:coconut_chronicles/core/storage/preferences_model.dart';
+import 'package:coconut_chronicles/widgets/chronicle_entry_list.dart';
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:scoped_model/scoped_model.dart';
@@ -19,6 +20,8 @@ class _HomePageDrawerState extends State<HomePageDrawer> {
           DrawerHeader(
             child: Container(),
           ),
+          const ChronicleEntryList(),
+          const Divider(),
           FutureBuilder<PackageInfo>(
               future: PackageInfo.fromPlatform(),
               builder: (BuildContext context, AsyncSnapshot<PackageInfo> snapshot) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
   encrypt: ^5.0.1
   sqflite: ^2.2.4+1
   country_picker: ^2.0.20
+  permission_handler: ^10.2.0
+  path_provider: ^2.0.14
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13091188/230661118-d73f54ee-f502-4e1f-a22f-b9bedc799626.png)

Entries are now saved to the platforms documents in a simple json wrote, and can be re-read back into the app.

added simple permission checking logic for android/ios/windows also