### PR TITLE
Basic support for editing old entries

### DIFF
--- a/lib/core/helpers/io_helper.dart
+++ b/lib/core/helpers/io_helper.dart
@@ -1,4 +1,4 @@
 class IoHelper {
-  static int saveDateToFile(DateTime dateTime) => dateTime.millisecondsSinceEpoch;
-  static DateTime readDateFromSave(int epoch) => DateTime.fromMillisecondsSinceEpoch(epoch);
+  static int? saveDateToFile(DateTime? dateTime) => dateTime?.millisecondsSinceEpoch;
+  static DateTime? readDateFromSave(int? epoch) => epoch == null ? null : DateTime.fromMillisecondsSinceEpoch(epoch);
 }

--- a/lib/core/models/entry_model.dart
+++ b/lib/core/models/entry_model.dart
@@ -2,11 +2,8 @@ import 'dart:convert';
 
 import 'package:coconut_chronicles/core/helpers/format_helper.dart';
 import 'package:coconut_chronicles/core/helpers/io_helper.dart';
-import 'package:flutter/material.dart';
-import 'package:scoped_model/scoped_model.dart';
 
-class EntryModel extends Model {
-  static EntryModel of(BuildContext context) => ScopedModel.of<EntryModel>(context);
+class EntryModel {
   static EntryModel newEntry() => EntryModel(createdAt: DateTime.now());
 
   String get safeTitle => title ?? "Untitled";
@@ -46,25 +43,19 @@ class EntryModel extends Model {
     _isNewEntry = title == null;
   }
 
-  void updateProperties({
-    String? title,
-    String? description,
-    DateTime? date,
-    DateTime? endDate,
-    String? country,
-    List<String>? categories,
-    bool rebuildListeners = false,
-  }) {
+  void updateProperties(
+      {String? title,
+      String? description,
+      DateTime? date,
+      DateTime? endDate,
+      String? country,
+      List<String>? categories}) {
     this.title = title ?? this.title;
     this.description = description ?? this.description;
     this.date = date ?? this.date;
     this.endDate = endDate ?? this.endDate;
     this.country = country ?? this.country;
     this.categories = categories ?? this.categories;
-
-    if (rebuildListeners) {
-      notifyListeners();
-    }
   }
 
   void clearProperties() {
@@ -75,8 +66,6 @@ class EntryModel extends Model {
     endDate = null;
     country = null;
     categories = [];
-
-    notifyListeners();
   }
 
   void addCategory(String category) {

--- a/lib/core/models/entry_model.dart
+++ b/lib/core/models/entry_model.dart
@@ -74,8 +74,8 @@ class EntryModel {
       'description': description,
       'country': country,
       'createdAt': IoHelper.saveDateToFile(createdAt),
-      'date': date != null ? IoHelper.saveDateToFile(date!) : null,
-      'endDate': endDate != null ? IoHelper.saveDateToFile(endDate!) : null,
+      'date': IoHelper.saveDateToFile(date),
+      'endDate': IoHelper.saveDateToFile(endDate),
       'categories': categories,
     });
   }
@@ -86,9 +86,9 @@ class EntryModel {
       title: decodedJson['title'],
       description: decodedJson['description'],
       country: decodedJson['country'],
-      createdAt: IoHelper.readDateFromSave(decodedJson['createdAt']),
-      date: IoHelper.readDateFromSave(decodedJson['createdAt']),
-      endDate: IoHelper.readDateFromSave(decodedJson['createdAt']),
+      createdAt: IoHelper.readDateFromSave(decodedJson['createdAt'])!, // This should never be null
+      date: IoHelper.readDateFromSave(decodedJson['date']),
+      endDate: IoHelper.readDateFromSave(decodedJson['endDate']),
       categories: List<String>.from(decodedJson['categories']),
     );
   }

--- a/lib/core/models/entry_model.dart
+++ b/lib/core/models/entry_model.dart
@@ -58,16 +58,6 @@ class EntryModel {
     this.categories = categories ?? this.categories;
   }
 
-  void clearProperties() {
-    title = null;
-    description = null;
-    createdAt = DateTime.now();
-    date = null;
-    endDate = null;
-    country = null;
-    categories = [];
-  }
-
   void addCategory(String category) {
     if (!categories.contains(category)) {
       categories.add(category);
@@ -84,7 +74,7 @@ class EntryModel {
       'description': description,
       'country': country,
       'createdAt': IoHelper.saveDateToFile(createdAt),
-      'date': IoHelper.saveDateToFile(date!),
+      'date': date != null ? IoHelper.saveDateToFile(date!) : null,
       'endDate': endDate != null ? IoHelper.saveDateToFile(endDate!) : null,
       'categories': categories,
     });
@@ -102,4 +92,6 @@ class EntryModel {
       categories: List<String>.from(decodedJson['categories']),
     );
   }
+
+  static EntryModel clone(EntryModel entry) => fromJson(entry.toJson());
 }

--- a/lib/core/models/selected_entry_model.dart
+++ b/lib/core/models/selected_entry_model.dart
@@ -9,10 +9,28 @@ class SelectedEntryModel extends Model {
   EntryModel _selectedEntry = EntryModel.newEntry();
   EntryModel get selectedEntry => _selectedEntry;
 
-  void selectEntry(EntryModel entry) {
-    var triggerNotify = _selectedEntry.fileSaveName != entry.fileSaveName;
-    _selectedEntry = entry;
+  // Global variables related to the entry form
+  final GlobalKey<FormState> _entryFormKey = GlobalKey<FormState>();
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
 
-    if (triggerNotify) notifyListeners();
+  GlobalKey<FormState> get entryFormKey => _entryFormKey;
+  TextEditingController get titleController => _titleController;
+  TextEditingController get descriptionController => _descriptionController;
+
+  void selectEntry(EntryModel entry) {
+    if (_selectedEntry.fileSaveName == entry.fileSaveName) return;
+
+    // Clone to avoid modifying the original entry
+    _selectedEntry = EntryModel.clone(entry);
+
+    _titleController.text = entry.title ?? '';
+    _descriptionController.text = entry.description ?? '';
+
+    notifyListeners();
+  }
+
+  void clearEntryForm() {
+    selectEntry(EntryModel.newEntry());
   }
 }

--- a/lib/core/models/selected_entry_model.dart
+++ b/lib/core/models/selected_entry_model.dart
@@ -1,0 +1,16 @@
+import 'package:coconut_chronicles/core/models/entry_model.dart';
+import 'package:flutter/material.dart';
+import 'package:scoped_model/scoped_model.dart';
+
+class SelectedEntryModel extends Model {
+  static SelectedEntryModel of(BuildContext context) => ScopedModel.of<SelectedEntryModel>(context);
+  static EntryModel getSelectedEntry(BuildContext context) => of(context).selectedEntry;
+
+  EntryModel _selectedEntry = EntryModel.newEntry();
+  EntryModel get selectedEntry => _selectedEntry;
+
+  void selectEntry(EntryModel entry) {
+    _selectedEntry = entry;
+    notifyListeners();
+  }
+}

--- a/lib/core/models/selected_entry_model.dart
+++ b/lib/core/models/selected_entry_model.dart
@@ -10,7 +10,9 @@ class SelectedEntryModel extends Model {
   EntryModel get selectedEntry => _selectedEntry;
   bool get isNewEntry => _selectedEntry.isNewEntry;
 
-  late EntryModel _originalEntry = _selectedEntry;
+  // This will always store the original entry ref, while _selectedEntry will be a clone
+  // For the initial setup, it is OK to have two new entries to mimic this behaviour.
+  EntryModel _originalEntry = EntryModel.newEntry();
 
   // Global variables related to the entry form
   final GlobalKey<FormState> _entryFormKey = GlobalKey<FormState>();
@@ -36,9 +38,5 @@ class SelectedEntryModel extends Model {
 
   void resetEntryForm() {
     selectEntry(_originalEntry, forceUpdate: true);
-  }
-
-  void clearEntryForm() {
-    selectEntry(EntryModel.newEntry());
   }
 }

--- a/lib/core/models/selected_entry_model.dart
+++ b/lib/core/models/selected_entry_model.dart
@@ -8,6 +8,9 @@ class SelectedEntryModel extends Model {
 
   EntryModel _selectedEntry = EntryModel.newEntry();
   EntryModel get selectedEntry => _selectedEntry;
+  bool get isNewEntry => _selectedEntry.isNewEntry;
+
+  late EntryModel _originalEntry = _selectedEntry;
 
   // Global variables related to the entry form
   final GlobalKey<FormState> _entryFormKey = GlobalKey<FormState>();
@@ -18,16 +21,21 @@ class SelectedEntryModel extends Model {
   TextEditingController get titleController => _titleController;
   TextEditingController get descriptionController => _descriptionController;
 
-  void selectEntry(EntryModel entry) {
-    if (_selectedEntry.fileSaveName == entry.fileSaveName) return;
+  void selectEntry(EntryModel entry, {bool forceUpdate = false}) {
+    if (_selectedEntry.fileSaveName == entry.fileSaveName && !forceUpdate) return;
 
     // Clone to avoid modifying the original entry
     _selectedEntry = EntryModel.clone(entry);
+    _originalEntry = entry;
 
     _titleController.text = entry.title ?? '';
     _descriptionController.text = entry.description ?? '';
 
     notifyListeners();
+  }
+
+  void resetEntryForm() {
+    selectEntry(_originalEntry, forceUpdate: true);
   }
 
   void clearEntryForm() {

--- a/lib/core/models/selected_entry_model.dart
+++ b/lib/core/models/selected_entry_model.dart
@@ -10,7 +10,9 @@ class SelectedEntryModel extends Model {
   EntryModel get selectedEntry => _selectedEntry;
 
   void selectEntry(EntryModel entry) {
+    var triggerNotify = _selectedEntry.fileSaveName != entry.fileSaveName;
     _selectedEntry = entry;
-    notifyListeners();
+
+    if (triggerNotify) notifyListeners();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
 import 'package:coconut_chronicles/core/storage/preferences_model.dart';
 import 'package:coconut_chronicles/pages/home_page.dart';
 import 'package:flutter/material.dart';
@@ -9,10 +10,15 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   var sharedPreferences = await SharedPreferences.getInstance();
 
+  var preferencesModel = PreferencesModel(sharedPreferences);
+  var selectedEntryModel = SelectedEntryModel();
+
   runApp(ScopedModel<PreferencesModel>(
-    model: PreferencesModel(sharedPreferences),
-    child: const CoreApp(),
-  ));
+      model: preferencesModel,
+      child: ScopedModel<SelectedEntryModel>(
+        model: selectedEntryModel,
+        child: const CoreApp(),
+      )));
 }
 
 class CoreApp extends StatelessWidget {
@@ -25,15 +31,14 @@ class CoreApp extends StatelessWidget {
       DeviceOrientation.portraitDown,
     ]);
 
-    return ScopedModelDescendant<PreferencesModel>(
-        builder: (context, child, model) => MaterialApp(
-              title: 'Coconut Chronicles',
-              theme: ThemeData(
-                useMaterial3: true,
-                colorSchemeSeed: Colors.blue,
-              ),
-              debugShowCheckedModeBanner: false,
-              home: const HomePage(),
-            ));
+    return MaterialApp(
+      title: 'Coconut Chronicles',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: Colors.blue,
+      ),
+      debugShowCheckedModeBanner: false,
+      home: const HomePage(),
+    );
   }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -19,7 +19,7 @@ class HomePageState extends State<HomePage> {
     return Scaffold(
       appBar: AppBar(
         title: ScopedModelDescendant<SelectedEntryModel>(builder: (context, child, model) {
-          return Text(model.selectedEntry.isNewEntry ? 'New entry' : model.selectedEntry.safeTitle);
+          return Text(model.isNewEntry ? 'New entry' : model.selectedEntry.safeTitle);
         }),
       ),
       // floatingActionButton: const HomePageFab(),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,6 +1,8 @@
+import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
 import 'package:coconut_chronicles/widgets/entry_form/chronicle_entry_form.dart';
 import 'package:coconut_chronicles/widgets/home_page_drawer.dart';
 import 'package:flutter/material.dart';
+import 'package:scoped_model/scoped_model.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -16,7 +18,9 @@ class HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('New entry'),
+        title: ScopedModelDescendant<SelectedEntryModel>(builder: (context, child, model) {
+          return Text(model.selectedEntry.isNewEntry ? 'New entry' : model.selectedEntry.safeTitle);
+        }),
       ),
       // floatingActionButton: const HomePageFab(),
       drawer: const HomePageDrawer(),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,8 +1,6 @@
-import 'package:coconut_chronicles/core/models/entry_model.dart';
 import 'package:coconut_chronicles/widgets/entry_form/chronicle_entry_form.dart';
 import 'package:coconut_chronicles/widgets/home_page_drawer.dart';
 import 'package:flutter/material.dart';
-import 'package:scoped_model/scoped_model.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -13,23 +11,20 @@ class HomePage extends StatefulWidget {
 
 class HomePageState extends State<HomePage> {
   static const double horizontalPadding = 32;
-  static final EntryModel _newEntry = EntryModel.newEntry();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('New entry'),
-        ),
-        // floatingActionButton: const HomePageFab(),
-        drawer: const HomePageDrawer(),
-        body: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: horizontalPadding),
-          child: ScopedModel<EntryModel>(
-            model: _newEntry,
-            child: const ChronicleEntryForm(),
-          ),
-        ));
+      appBar: AppBar(
+        title: const Text('New entry'),
+      ),
+      // floatingActionButton: const HomePageFab(),
+      drawer: const HomePageDrawer(),
+      body: const Padding(
+        padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+        child: ChronicleEntryForm(),
+      ),
+    );
   }
 
   @override

--- a/lib/widgets/chronicle_entry_list.dart
+++ b/lib/widgets/chronicle_entry_list.dart
@@ -1,4 +1,5 @@
 import 'package:coconut_chronicles/core/models/entry_model.dart';
+import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
 import 'package:coconut_chronicles/core/storage/entry_storage.dart';
 import 'package:coconut_chronicles/widgets/entry_list_tile.dart';
 import 'package:flutter/material.dart';
@@ -13,6 +14,8 @@ class ChronicleEntryList extends StatefulWidget {
 class _ChronicleEntryListState extends State<ChronicleEntryList> {
   @override
   Widget build(BuildContext context) {
+    var selectedEntryModel = SelectedEntryModel.of(context);
+
     return Column(children: [
       const Text("Past entries"),
       SizedBox(
@@ -31,7 +34,14 @@ class _ChronicleEntryListState extends State<ChronicleEntryList> {
                   itemCount: entries.length,
                   itemBuilder: (context, index) {
                     var entry = entries[index];
-                    return EntryListTitle(entry: entry, onTap: () => null);
+                    return EntryListTitle(
+                        entry: entry,
+                        onTap: () {
+                          selectedEntryModel.selectEntry(entry);
+
+                          // TODO this only works within the context of a drawer
+                          Navigator.pop(context);
+                        });
                   },
                 );
               }

--- a/lib/widgets/dialogues/confirmation_dialogue_builder.dart
+++ b/lib/widgets/dialogues/confirmation_dialogue_builder.dart
@@ -1,57 +1,58 @@
 import 'package:flutter/material.dart';
 
 class ConfirmationDialogueBuilder {
-  static void showConfirmToClearEntryFormDialogue(BuildContext context, {required VoidCallback onConfirm}) {
-    showConfirmationDialogue(
+  static Future<bool> showClearEntryForm(BuildContext context) async {
+    return await _showConfirmationDialogue(
       context,
       title: "Clear current entry",
       content: "Are you sure you want to clear all data?",
       confirmText: "Clear",
       cancelText: "Cancel",
-      onConfirm: onConfirm,
     );
   }
 
-  static void showConfirmToClearEncryptionKeyDialogue(BuildContext context, {required VoidCallback onConfirm}) {
-    showConfirmationDialogue(
+  static Future<bool> showConfirmUndoChanges(BuildContext context) async {
+    return await _showConfirmationDialogue(
+      context,
+      title: "Undo changes",
+      content: "Are you sure you want to undo all changes?",
+      confirmText: "Undo",
+      cancelText: "Cancel",
+    );
+  }
+
+  static Future<bool> showClearEncryptionKey(BuildContext context) async {
+    return await _showConfirmationDialogue(
       context,
       title: "Clear encryption key",
       content: "Are you sure you want to clear the encryption key?",
       confirmText: "Clear",
       cancelText: "Cancel",
-      onConfirm: onConfirm,
     );
   }
 
-  static void showConfirmationDialogue(
-    BuildContext context, {
-    required String title,
-    required String content,
-    required String confirmText,
-    required String cancelText,
-    required VoidCallback onConfirm,
-  }) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(title),
-        content: Text(content),
-        actions: [
-          TextButton(
-            child: Text(cancelText),
-            onPressed: () {
-              Navigator.of(context).pop();
-            },
-          ),
-          TextButton(
-            child: Text(confirmText),
-            onPressed: () {
-              Navigator.of(context).pop();
-              onConfirm();
-            },
-          ),
-        ],
-      ),
-    );
+  static Future<bool> _showConfirmationDialogue(BuildContext context,
+      {required String title, required String content, required String confirmText, required String cancelText}) async {
+    var result = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+              title: Text(title),
+              content: Text(content),
+              actions: [
+                TextButton(
+                  child: Text(cancelText),
+                  onPressed: () {
+                    Navigator.of(context).pop(false);
+                  },
+                ),
+                TextButton(
+                  child: Text(confirmText),
+                  onPressed: () {
+                    Navigator.of(context).pop(true);
+                  },
+                ),
+              ],
+            ));
+    return result ?? false;
   }
 }

--- a/lib/widgets/drawer/encryption_options.dart
+++ b/lib/widgets/drawer/encryption_options.dart
@@ -49,9 +49,10 @@ class _EncryptionOptionsState extends State<EncryptionOptions> {
   }
 
   _tryClearEncryptionKey() async {
-    ConfirmationDialogueBuilder.showConfirmToClearEncryptionKeyDialogue(context, onConfirm: () async {
+    var clearConfirmation = await ConfirmationDialogueBuilder.showClearEncryptionKey(context);
+    if (clearConfirmation) {
       await Encryption.clearEncryptionKey();
       setState(() {});
-    });
+    }
   }
 }

--- a/lib/widgets/entry_form/chronicle_entry_form.dart
+++ b/lib/widgets/entry_form/chronicle_entry_form.dart
@@ -1,5 +1,5 @@
 import 'package:coconut_chronicles/constants/default_constants.dart';
-import 'package:coconut_chronicles/core/models/entry_model.dart';
+import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
 import 'package:coconut_chronicles/core/storage/entry_storage.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/chip_categories.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/country_selector.dart';
@@ -9,7 +9,6 @@ import 'package:coconut_chronicles/widgets/entry_form/inputs/description_text_fi
 import 'package:coconut_chronicles/widgets/entry_form/inputs/indented_category_text.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/title_text_field.dart';
 import 'package:flutter/material.dart';
-import 'package:scoped_model/scoped_model.dart';
 
 class ChronicleEntryForm extends StatefulWidget {
   const ChronicleEntryForm({Key? key}) : super(key: key);
@@ -66,7 +65,7 @@ class _ChronicleEntryFormState extends State<ChronicleEntryForm> {
 
   _saveEntry() async {
     var snackContext = ScaffoldMessenger.of(context);
-    bool success = await EntryStorage.saveEntry(ScopedModel.of<EntryModel>(context));
+    bool success = await EntryStorage.saveEntry(SelectedEntryModel.getSelectedEntry(context));
     if (success) {
       _clearData();
       snackContext.showSnackBar(
@@ -80,7 +79,7 @@ class _ChronicleEntryFormState extends State<ChronicleEntryForm> {
   }
 
   _clearData() {
-    var entry = ScopedModel.of<EntryModel>(context);
+    var entry = SelectedEntryModel.getSelectedEntry(context);
     if (entry.isNewEntry) {
       entry.clearProperties();
     }

--- a/lib/widgets/entry_form/chronicle_entry_form.dart
+++ b/lib/widgets/entry_form/chronicle_entry_form.dart
@@ -1,89 +1,37 @@
 import 'package:coconut_chronicles/constants/default_constants.dart';
 import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
-import 'package:coconut_chronicles/core/storage/entry_storage.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/chip_categories.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/country_selector.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/date_selectors.dart';
-import 'package:coconut_chronicles/widgets/dialogues/confirmation_dialogue_builder.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/description_text_field.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/indented_category_text.dart';
+import 'package:coconut_chronicles/widgets/entry_form/inputs/submission_buttons.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/title_text_field.dart';
 import 'package:flutter/material.dart';
 
-class ChronicleEntryForm extends StatefulWidget {
+class ChronicleEntryForm extends StatelessWidget {
   const ChronicleEntryForm({Key? key}) : super(key: key);
-
-  @override
-  State<ChronicleEntryForm> createState() => _ChronicleEntryFormState();
-}
-
-class _ChronicleEntryFormState extends State<ChronicleEntryForm> {
-  final _formKey = GlobalKey<FormState>();
 
   @override
   Widget build(BuildContext context) {
     return Form(
-      key: _formKey,
-      child: ListView(children: [
-        const SizedBox(height: 4),
-        const TitleTextField(),
-        const SizedBox(height: 8),
-        const DateSelectors(),
-        const Divider(),
-        const CountrySelector(),
-        const SizedBox(height: 8),
-        const DescriptionTextField(),
-        const SizedBox(height: 8),
-        const IndentedCategoryText(text: 'Categories'),
-        const SizedBox(height: 8),
-        const ChipCategories(categories: DefaultConstants.defaultChipSuggestions),
-        const Divider(height: 32),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [
-            TextButton(
-              onPressed: () =>
-                  ConfirmationDialogueBuilder.showConfirmToClearEntryFormDialogue(context, onConfirm: _clearData),
-              child: const Text('Clear'),
-            ),
-            TextButton(
-              onPressed: () {
-                if (_formKey.currentState!.validate()) {
-                  _saveEntry();
-                }
-              },
-              child: const Text('Save'),
-            ),
-            const SizedBox(
-              width: 8,
-            ),
-          ],
-        ),
+      key: SelectedEntryModel.of(context).entryFormKey,
+      child: ListView(children: const [
+        SizedBox(height: 4),
+        TitleTextField(),
+        SizedBox(height: 8),
+        DateSelectors(),
+        Divider(),
+        CountrySelector(),
+        SizedBox(height: 8),
+        DescriptionTextField(),
+        SizedBox(height: 8),
+        IndentedCategoryText(text: 'Categories'),
+        SizedBox(height: 8),
+        ChipCategories(categories: DefaultConstants.defaultChipSuggestions),
+        Divider(height: 32),
+        SubmissionButtons(),
       ]),
     );
-  }
-
-  _saveEntry() async {
-    var snackContext = ScaffoldMessenger.of(context);
-    bool success = await EntryStorage.saveEntry(SelectedEntryModel.getSelectedEntry(context));
-    if (success) {
-      _clearData();
-      snackContext.showSnackBar(
-        const SnackBar(content: Text('Saved chronicle entry')),
-      );
-    } else {
-      snackContext.showSnackBar(
-        const SnackBar(content: Text('Error saving chronicle entry')),
-      );
-    }
-  }
-
-  _clearData() {
-    var entry = SelectedEntryModel.getSelectedEntry(context);
-    if (entry.isNewEntry) {
-      entry.clearProperties();
-    }
-
-    _formKey.currentState?.reset();
   }
 }

--- a/lib/widgets/entry_form/inputs/chip_categories.dart
+++ b/lib/widgets/entry_form/inputs/chip_categories.dart
@@ -1,4 +1,4 @@
-import 'package:coconut_chronicles/core/models/entry_model.dart';
+import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
 import 'package:flutter/material.dart';
 import 'package:scoped_model/scoped_model.dart';
 
@@ -14,7 +14,7 @@ class ChipCategories extends StatefulWidget {
 class _ChipCategoriesState extends State<ChipCategories> {
   @override
   Widget build(BuildContext context) {
-    return ScopedModelDescendant<EntryModel>(
+    return ScopedModelDescendant<SelectedEntryModel>(
         builder: (context, child, model) => Wrap(
               spacing: 8.0,
               runSpacing: 4,
@@ -22,13 +22,13 @@ class _ChipCategoriesState extends State<ChipCategories> {
                   .map((category) => FilterChip(
                         label: Text(category),
                         shape: const StadiumBorder(),
-                        selected: model.categories.contains(category),
+                        selected: model.selectedEntry.categories.contains(category),
                         onSelected: (bool value) {
                           setState(() {
                             if (value) {
-                              model.addCategory(category);
+                              model.selectedEntry.addCategory(category);
                             } else {
-                              model.removeCategory(category);
+                              model.selectedEntry.removeCategory(category);
                             }
                           });
                         },

--- a/lib/widgets/entry_form/inputs/country_selector.dart
+++ b/lib/widgets/entry_form/inputs/country_selector.dart
@@ -1,5 +1,5 @@
 import 'package:coconut_chronicles/core/helpers/validator_helper.dart';
-import 'package:coconut_chronicles/core/models/entry_model.dart';
+import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/indented_category_text.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/validation_error_text.dart';
 import 'package:country_picker/country_picker.dart';
@@ -16,7 +16,7 @@ class CountrySelector extends StatefulWidget {
 class _CountrySelectorState extends State<CountrySelector> {
   @override
   Widget build(BuildContext context) {
-    return ScopedModelDescendant<EntryModel>(
+    return ScopedModelDescendant<SelectedEntryModel>(
       builder: (context, child, model) => FormField<String>(
         builder: (state) => Column(children: [
           Row(
@@ -24,7 +24,7 @@ class _CountrySelectorState extends State<CountrySelector> {
               const IndentedCategoryText(text: 'Country: '),
               TextButton(
                 onPressed: () => _openCountryPicker(),
-                child: Text(model.safeCountry),
+                child: Text(model.selectedEntry.safeCountry),
               ),
             ],
           ),
@@ -33,7 +33,7 @@ class _CountrySelectorState extends State<CountrySelector> {
               errorText: state.errorText!,
             ),
         ]),
-        validator: (_) => ValidatorHelper.emptyCountryValidator(model.country),
+        validator: (_) => ValidatorHelper.emptyCountryValidator(model.selectedEntry.country),
       ),
     );
   }
@@ -59,7 +59,7 @@ class _CountrySelectorState extends State<CountrySelector> {
       ),
       onSelect: (Country country) => {
         setState(() {
-          ScopedModel.of<EntryModel>(context).updateProperties(country: country.name);
+          ScopedModel.of<SelectedEntryModel>(context).selectedEntry.updateProperties(country: country.name);
         })
       },
     );

--- a/lib/widgets/entry_form/inputs/date_selectors.dart
+++ b/lib/widgets/entry_form/inputs/date_selectors.dart
@@ -1,5 +1,5 @@
 import 'package:coconut_chronicles/core/helpers/validator_helper.dart';
-import 'package:coconut_chronicles/core/models/entry_model.dart';
+import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/indented_category_text.dart';
 import 'package:coconut_chronicles/widgets/entry_form/inputs/validation_error_text.dart';
 import 'package:flutter/material.dart';
@@ -19,7 +19,7 @@ class _DateSelectorsState extends State<DateSelectors> {
 
   @override
   Widget build(BuildContext context) {
-    return ScopedModelDescendant<EntryModel>(
+    return ScopedModelDescendant<SelectedEntryModel>(
       builder: (context, child, model) => Column(children: [
         Row(
           children: [
@@ -29,8 +29,8 @@ class _DateSelectorsState extends State<DateSelectors> {
                   Row(children: [
                     const IndentedCategoryText(text: 'Date: '),
                     TextButton(
-                      onPressed: () => _openDatePicker(currentDate: model.date, endDate: false),
-                      child: Text(model.safeDate),
+                      onPressed: () => _openDatePicker(currentDate: model.selectedEntry.date, endDate: false),
+                      child: Text(model.selectedEntry.safeDate),
                     ),
                   ]),
                   if (state.hasError)
@@ -39,7 +39,7 @@ class _DateSelectorsState extends State<DateSelectors> {
                     ),
                 ],
               ),
-              validator: (_) => ValidatorHelper.emptyDateValidator(model.date),
+              validator: (_) => ValidatorHelper.emptyDateValidator(model.selectedEntry.date),
             )
           ],
         ),
@@ -48,15 +48,15 @@ class _DateSelectorsState extends State<DateSelectors> {
             text: 'End Date (Optional): ',
           ),
           TextButton(
-              onPressed: () => _openDatePicker(currentDate: model.endDate, endDate: true),
-              child: Text(model.safeEndDate)),
+              onPressed: () => _openDatePicker(currentDate: model.selectedEntry.endDate, endDate: true),
+              child: Text(model.selectedEntry.safeEndDate)),
         ]),
       ]),
     );
   }
 
   Future<void> _openDatePicker({required DateTime? currentDate, required bool endDate}) async {
-    var entry = ScopedModel.of<EntryModel>(context);
+    var entry = ScopedModel.of<SelectedEntryModel>(context).selectedEntry;
     final DateTime? picked = await showDatePicker(
       context: context,
       helpText: "Date of memory",

--- a/lib/widgets/entry_form/inputs/description_text_field.dart
+++ b/lib/widgets/entry_form/inputs/description_text_field.dart
@@ -1,5 +1,5 @@
 import 'package:coconut_chronicles/core/helpers/validator_helper.dart';
-import 'package:coconut_chronicles/core/models/entry_model.dart';
+import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
 import 'package:flutter/material.dart';
 import 'package:scoped_model/scoped_model.dart';
 
@@ -8,7 +8,7 @@ class DescriptionTextField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ScopedModelDescendant<EntryModel>(
+    return ScopedModelDescendant<SelectedEntryModel>(
         builder: (context, child, model) => TextFormField(
               decoration: const InputDecoration(
                 border: OutlineInputBorder(),
@@ -16,7 +16,8 @@ class DescriptionTextField extends StatelessWidget {
               ),
               maxLines: null,
               minLines: 10,
-              onChanged: (value) => model.updateProperties(description: value),
+              initialValue: model.selectedEntry.description,
+              onChanged: (value) => model.selectedEntry.updateProperties(description: value),
               textAlignVertical: TextAlignVertical.top,
               keyboardType: TextInputType.multiline,
               textCapitalization: TextCapitalization.sentences,

--- a/lib/widgets/entry_form/inputs/description_text_field.dart
+++ b/lib/widgets/entry_form/inputs/description_text_field.dart
@@ -16,7 +16,7 @@ class DescriptionTextField extends StatelessWidget {
               ),
               maxLines: null,
               minLines: 10,
-              initialValue: model.selectedEntry.description,
+              controller: SelectedEntryModel.of(context).descriptionController,
               onChanged: (value) => model.selectedEntry.updateProperties(description: value),
               textAlignVertical: TextAlignVertical.top,
               keyboardType: TextInputType.multiline,

--- a/lib/widgets/entry_form/inputs/submission_buttons.dart
+++ b/lib/widgets/entry_form/inputs/submission_buttons.dart
@@ -21,7 +21,7 @@ class _SubmissionButtonsState extends State<SubmissionButtons> {
           TextButton(
             onPressed: () =>
                 ConfirmationDialogueBuilder.showConfirmToClearEntryFormDialogue(context, onConfirm: _clearData),
-            child: Text(model.selectedEntry.isNewEntry ? 'Clear' : 'Undo changes'),
+            child: Text(model.isNewEntry ? 'Clear' : 'Undo changes'),
           ),
           TextButton(
             onPressed: () {
@@ -29,7 +29,7 @@ class _SubmissionButtonsState extends State<SubmissionButtons> {
                 _saveEntry();
               }
             },
-            child: Text(model.selectedEntry.isNewEntry ? 'Save' : 'Update'),
+            child: Text(model.isNewEntry ? 'Save' : 'Update'),
           ),
           const SizedBox(
             width: 8,
@@ -55,6 +55,11 @@ class _SubmissionButtonsState extends State<SubmissionButtons> {
   }
 
   _clearData() {
-    SelectedEntryModel.of(context).clearEntryForm();
+    var model = SelectedEntryModel.of(context);
+    if (model.isNewEntry) {
+      model.clearEntryForm();
+    } else {
+      model.resetEntryForm();
+    }
   }
 }

--- a/lib/widgets/entry_form/inputs/submission_buttons.dart
+++ b/lib/widgets/entry_form/inputs/submission_buttons.dart
@@ -19,9 +19,11 @@ class _SubmissionButtonsState extends State<SubmissionButtons> {
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           TextButton(
-            onPressed: () =>
-                ConfirmationDialogueBuilder.showConfirmToClearEntryFormDialogue(context, onConfirm: _clearData),
+            onPressed: () => _clearData(),
             child: Text(model.isNewEntry ? 'Clear' : 'Undo changes'),
+          ),
+          const SizedBox(
+            width: 8,
           ),
           TextButton(
             onPressed: () {
@@ -29,7 +31,7 @@ class _SubmissionButtonsState extends State<SubmissionButtons> {
                 _saveEntry();
               }
             },
-            child: Text(model.isNewEntry ? 'Save' : 'Update'),
+            child: Text(model.isNewEntry ? 'Save entry' : 'Update entry'),
           ),
           const SizedBox(
             width: 8,
@@ -54,7 +56,15 @@ class _SubmissionButtonsState extends State<SubmissionButtons> {
     }
   }
 
-  _clearData() {
-    SelectedEntryModel.of(context).resetEntryForm();
+  _clearData() async {
+    var selectedModel = SelectedEntryModel.of(context);
+    var clearDialogue = selectedModel.isNewEntry
+        ? ConfirmationDialogueBuilder.showClearEntryForm(context)
+        : ConfirmationDialogueBuilder.showConfirmUndoChanges(context);
+
+    var result = await clearDialogue;
+    if (result) {
+      selectedModel.resetEntryForm();
+    }
   }
 }

--- a/lib/widgets/entry_form/inputs/submission_buttons.dart
+++ b/lib/widgets/entry_form/inputs/submission_buttons.dart
@@ -55,11 +55,6 @@ class _SubmissionButtonsState extends State<SubmissionButtons> {
   }
 
   _clearData() {
-    var model = SelectedEntryModel.of(context);
-    if (model.isNewEntry) {
-      model.clearEntryForm();
-    } else {
-      model.resetEntryForm();
-    }
+    SelectedEntryModel.of(context).resetEntryForm();
   }
 }

--- a/lib/widgets/entry_form/inputs/submission_buttons.dart
+++ b/lib/widgets/entry_form/inputs/submission_buttons.dart
@@ -1,0 +1,60 @@
+import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
+import 'package:coconut_chronicles/core/storage/entry_storage.dart';
+import 'package:coconut_chronicles/widgets/dialogues/confirmation_dialogue_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:scoped_model/scoped_model.dart';
+
+class SubmissionButtons extends StatefulWidget {
+  const SubmissionButtons({Key? key}) : super(key: key);
+
+  @override
+  State<SubmissionButtons> createState() => _SubmissionButtonsState();
+}
+
+class _SubmissionButtonsState extends State<SubmissionButtons> {
+  @override
+  Widget build(BuildContext context) {
+    return ScopedModelDescendant<SelectedEntryModel>(builder: (context, child, model) {
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          TextButton(
+            onPressed: () =>
+                ConfirmationDialogueBuilder.showConfirmToClearEntryFormDialogue(context, onConfirm: _clearData),
+            child: Text(model.selectedEntry.isNewEntry ? 'Clear' : 'Undo changes'),
+          ),
+          TextButton(
+            onPressed: () {
+              if (model.entryFormKey.currentState!.validate()) {
+                _saveEntry();
+              }
+            },
+            child: Text(model.selectedEntry.isNewEntry ? 'Save' : 'Update'),
+          ),
+          const SizedBox(
+            width: 8,
+          ),
+        ],
+      );
+    });
+  }
+
+  _saveEntry() async {
+    var snackContext = ScaffoldMessenger.of(context);
+    bool success = await EntryStorage.saveEntry(SelectedEntryModel.getSelectedEntry(context));
+    if (success) {
+      _clearData();
+      snackContext.showSnackBar(
+        const SnackBar(content: Text('Saved chronicle entry')),
+      );
+    } else {
+      snackContext.showSnackBar(
+        const SnackBar(content: Text('Error saving chronicle entry')),
+      );
+    }
+  }
+
+  _clearData() {
+    SelectedEntryModel.of(context).clearEntryForm();
+  }
+}

--- a/lib/widgets/entry_form/inputs/title_text_field.dart
+++ b/lib/widgets/entry_form/inputs/title_text_field.dart
@@ -1,5 +1,5 @@
 import 'package:coconut_chronicles/core/helpers/validator_helper.dart';
-import 'package:coconut_chronicles/core/models/entry_model.dart';
+import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
 import 'package:flutter/material.dart';
 import 'package:scoped_model/scoped_model.dart';
 
@@ -8,15 +8,15 @@ class TitleTextField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ScopedModelDescendant<EntryModel>(
+    return ScopedModelDescendant<SelectedEntryModel>(
         builder: (context, child, model) => TextFormField(
               autofocus: true,
               decoration: const InputDecoration(
                 border: OutlineInputBorder(),
                 labelText: 'Captivating title',
               ),
-              initialValue: model.title,
-              onChanged: (value) => model.updateProperties(title: value),
+              initialValue: model.selectedEntry.title,
+              onChanged: (value) => model.selectedEntry.updateProperties(title: value),
               validator: (value) => ValidatorHelper.emptyTextValidator(value),
             ));
   }

--- a/lib/widgets/entry_form/inputs/title_text_field.dart
+++ b/lib/widgets/entry_form/inputs/title_text_field.dart
@@ -3,14 +3,9 @@ import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
 import 'package:flutter/material.dart';
 import 'package:scoped_model/scoped_model.dart';
 
-class TitleTextField extends StatefulWidget {
+class TitleTextField extends StatelessWidget {
   const TitleTextField({Key? key}) : super(key: key);
 
-  @override
-  State<TitleTextField> createState() => _TitleTextFieldState();
-}
-
-class _TitleTextFieldState extends State<TitleTextField> {
   @override
   Widget build(BuildContext context) {
     return ScopedModelDescendant<SelectedEntryModel>(builder: (context, child, model) {
@@ -20,9 +15,10 @@ class _TitleTextFieldState extends State<TitleTextField> {
           border: OutlineInputBorder(),
           labelText: 'Captivating title',
         ),
-        initialValue: model.selectedEntry.title,
+        controller: SelectedEntryModel.of(context).titleController,
         onChanged: (value) => model.selectedEntry.updateProperties(title: value),
         validator: (value) => ValidatorHelper.emptyTextValidator(value),
+        textCapitalization: TextCapitalization.sentences,
       );
     });
   }

--- a/lib/widgets/entry_form/inputs/title_text_field.dart
+++ b/lib/widgets/entry_form/inputs/title_text_field.dart
@@ -3,21 +3,27 @@ import 'package:coconut_chronicles/core/models/selected_entry_model.dart';
 import 'package:flutter/material.dart';
 import 'package:scoped_model/scoped_model.dart';
 
-class TitleTextField extends StatelessWidget {
+class TitleTextField extends StatefulWidget {
   const TitleTextField({Key? key}) : super(key: key);
 
   @override
+  State<TitleTextField> createState() => _TitleTextFieldState();
+}
+
+class _TitleTextFieldState extends State<TitleTextField> {
+  @override
   Widget build(BuildContext context) {
-    return ScopedModelDescendant<SelectedEntryModel>(
-        builder: (context, child, model) => TextFormField(
-              autofocus: true,
-              decoration: const InputDecoration(
-                border: OutlineInputBorder(),
-                labelText: 'Captivating title',
-              ),
-              initialValue: model.selectedEntry.title,
-              onChanged: (value) => model.selectedEntry.updateProperties(title: value),
-              validator: (value) => ValidatorHelper.emptyTextValidator(value),
-            ));
+    return ScopedModelDescendant<SelectedEntryModel>(builder: (context, child, model) {
+      return TextFormField(
+        autofocus: true,
+        decoration: const InputDecoration(
+          border: OutlineInputBorder(),
+          labelText: 'Captivating title',
+        ),
+        initialValue: model.selectedEntry.title,
+        onChanged: (value) => model.selectedEntry.updateProperties(title: value),
+        validator: (value) => ValidatorHelper.emptyTextValidator(value),
+      );
+    });
   }
 }


### PR DESCRIPTION
<img width="820" alt="image" src="https://user-images.githubusercontent.com/13091188/233454681-819b9e64-4f7f-435f-b66a-08c3f4652aeb.png">

Refactored a lot of items, but key changes are:
- Exposed form key, and title + description controllers into a new model
- Ability to select + edit old entries
- Better handling of clearing new changes
- Ability now to un-do changes back to original entry, as we now clone the original object while editing.